### PR TITLE
Instructions pt2

### DIFF
--- a/src/lc3_vm.rs
+++ b/src/lc3_vm.rs
@@ -114,15 +114,15 @@ impl LC3VirtualMachine {
         self.update_flags(result);
     }
 
-    /// Load register instruction loads into dst register the content in the memory addres obtained by adding the 
+    /// Load register instruction loads into dst register the content in the memory addres obtained by adding the
     /// content of src register and offset (6 bit immediate).
     /// Load register alters flags depending the content loaded into the dst register.
-    fn load_register(&mut self,dst: Registers, src: Registers, offset: u16){
-        let result = self.memory[self.registers[src as usize].wrapping_add(self.extend_sign(offset, 6)) as usize];
+    fn load_register(&mut self, dst: Registers, src: Registers, offset: u16) {
+        let result = self.memory
+            [self.registers[src as usize].wrapping_add(self.extend_sign(offset, 6)) as usize];
         self.registers[dst as usize] = result;
         self.update_flags(result);
     }
-
 }
 
 enum Registers {

--- a/src/lc3_vm.rs
+++ b/src/lc3_vm.rs
@@ -150,7 +150,9 @@ impl LC3VirtualMachine {
     /// Store Indirect instruction stores in memory the content in the src register.
     /// The memory address to store de value is obtained from the memory position in address pc + pc_offset (9 bit immediate).
     fn store_indirect(&mut self, src: Registers, pc_offset: u16) {
-        let memory_address = self.memory[self.registers[Registers::PC as usize].wrapping_add(self.extend_sign(pc_offset, 9)) as usize];
+        let memory_address = self.memory[self.registers[Registers::PC as usize]
+            .wrapping_add(self.extend_sign(pc_offset, 9))
+            as usize];
         self.memory[memory_address as usize] = self.registers[src as usize];
     }
 }
@@ -495,7 +497,7 @@ mod tests {
         vm.memory[65530] = 50000;
         vm.registers[Registers::R1 as usize] = 65000;
         // PC is equal to 2 so the negative jump should be equal to -8 in 9 bits = 0b111111000
-        vm.store_indirect(Registers::R1,  0b111111000);
+        vm.store_indirect(Registers::R1, 0b111111000);
         assert_eq!(vm.memory[50000], 65000);
         assert_eq!(vm.registers[Registers::COND as usize], 0); // Check flags. 
     }

--- a/src/lc3_vm.rs
+++ b/src/lc3_vm.rs
@@ -113,6 +113,16 @@ impl LC3VirtualMachine {
         self.registers[dst as usize] = result;
         self.update_flags(result);
     }
+
+    /// Load register instruction loads into dst register the content in the memory addres obtained by adding the 
+    /// content of src register and offset (6 bit immediate).
+    /// Load register alters flags depending the content loaded into the dst register.
+    fn load_register(&mut self,dst: Registers, src: Registers, offset: u16){
+        let result = self.memory[self.registers[src as usize].wrapping_add(self.extend_sign(offset, 6)) as usize];
+        self.registers[dst as usize] = result;
+        self.update_flags(result);
+    }
+
 }
 
 enum Registers {


### PR DESCRIPTION
Instructions implemented with their corresponding tests:
- load register
- store register
- bitwise not
- load indirect
- store indirect